### PR TITLE
DT package should be suggested

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Imports:
     utils
 Suggests:
     knitr,
-    tidyr
+    tidyr,
+    DT
 License: Artistic-2.0
 VignetteBuilder: knitr
 ByteCompile: true


### PR DESCRIPTION
DT package is required to run the shiny apps, however, it is not suggested or required in the package description.