### PR TITLE
add an option to refresh cache

### DIFF
--- a/R/cran_stats.R
+++ b/R/cran_stats.R
@@ -3,6 +3,8 @@
 ##'
 ##' @title cran_stats
 ##' @param packages packages
+##' @param use_cache logical, should cached data be used? Default: TRUE. If set to FALSE, it will
+##'   re-query download stats and update cache.
 ##' @return data.frame
 ##' @importFrom jsonlite fromJSON
 ##' @importFrom magrittr %>%
@@ -10,14 +12,15 @@
 ##' @examples
 ##' \dontrun{
 ##' library("dlstats")
-##' x <- cran_stats(c("dlstats", "emojifont", "rvcheck"))
+##' x <- cran_stats(c("dlstats", "emojifont", "rvcheck"), use_cache=TRUE)
 ##' head(x)
 ##' }
 ##' @author Guangchuang Yu
-cran_stats <- function(packages) {
+cran_stats <- function(packages, use_cache=TRUE) {
     stats_cache <- get_from_cache(packages)
-    packages <- packages[!packages %in% stats_cache$package]
-
+    if (use_cache) {
+        packages <- packages[!packages %in% stats_cache$package]
+    }
     if (length(packages) == 0) {
         return(stats_cache)
     }
@@ -51,7 +54,8 @@ cran_stats <- function(packages) {
     res <- res[order(res$package, res$start),]
     dlstats_cache(res)
 
-    rbind(res, stats_cache)
+    if (use_cache) return(rbind(res, stats_cache))
+    return(res)
 }
 
 
@@ -60,6 +64,7 @@ setup_stats <- function(stats, packages) {
     stats$package <- factor(stats$package, levels=packages)
     stats$start %<>% as.Date
     stats$end %<>% as.Date
+    rownames(stats) <- NULL
     return(stats)
 }
 

--- a/man/bioc_stats.Rd
+++ b/man/bioc_stats.Rd
@@ -4,10 +4,13 @@
 \alias{bioc_stats}
 \title{bioc_stats}
 \usage{
-bioc_stats(packages)
+bioc_stats(packages, use_cache = TRUE)
 }
 \arguments{
 \item{packages}{packages}
+
+\item{use_cache}{logical, should cached data be used? Default: TRUE. If set to FALSE, it will
+re-query download stats and update cache.}
 }
 \value{
 data.frame
@@ -19,11 +22,10 @@ monthly download stats of cran package(s)
 \dontrun{
 library("dlstats")
 pkgs <- c("ChIPseeker", "clusterProfiler", "DOSE", "ggtree", "GOSemSim", "ReactomePA")
-y <- bioc_stats(pkgs)
+y <- bioc_stats(pkgs, use_cache=TRUE)
 head(y)
 }
 }
 \author{
 Guangchuang Yu
 }
-

--- a/man/cran_stats.Rd
+++ b/man/cran_stats.Rd
@@ -4,10 +4,13 @@
 \alias{cran_stats}
 \title{cran_stats}
 \usage{
-cran_stats(packages)
+cran_stats(packages, use_cache = TRUE)
 }
 \arguments{
 \item{packages}{packages}
+
+\item{use_cache}{logical, should cached data be used? Default: TRUE. If set to FALSE, it will
+re-query download stats and update cache.}
 }
 \value{
 data.frame
@@ -18,11 +21,10 @@ monthly download stats of cran package(s)
 \examples{
 \dontrun{
 library("dlstats")
-x <- cran_stats(c("dlstats", "emojifont", "rvcheck"))
+x <- cran_stats(c("dlstats", "emojifont", "rvcheck"), use_cache=TRUE)
 head(x)
 }
 }
 \author{
 Guangchuang Yu
 }
-


### PR DESCRIPTION
As someone who doesn't restart his R session for weeks, I found it helpful to have an option to refresh the cache when checking download stats. This PR adds an option to `cran_stats` and `bioc_stats` that allows user to not use cached stats (i.e. re-query stats and update cache).

For example, I did this yesterday
```
> cran_stats("dlstats")
        start        end downloads package
1  2016-06-01 2016-06-30        46 dlstats
... 
29 2018-10-01 2018-10-09       151 dlstats
```
And came back today, still using cached data
```
> cran_stats("dlstats")
        start        end downloads package
1  2016-06-01 2016-06-30        46 dlstats
... 
29 2018-10-01 2018-10-09       151 dlstats
```
With `use_cache=FALSE`, re-query and update cache
```
> cran_stats("dlstats", use_cache=FALSE)
        start        end downloads package
1  2016-06-01 2016-06-30        46 dlstats
... 
29 2018-10-01 2018-10-10       167 dlstats
```
So, 16 downloads during the past day 🎉 