### PR TITLE
Progress bar simple

### DIFF
--- a/R/cran_stats.R
+++ b/R/cran_stats.R
@@ -1,15 +1,20 @@
-##' monthly download stats of cran package(s)
-##'
-##'
-##' @title cran_stats
-##' @param packages packages
-##' @param use_cache logical, should cached data be used? Default: TRUE. If set to FALSE, it will re-query download stats and update cache.
-##' @param progress logical, should a progress bar be shown? Default: TRUE. When TRUE, a text progress bar will display “fetching data for `year-month`” as each month’s range is fetched.
-##' @return data.frame
-##' @importFrom jsonlite fromJSON
-##' @importFrom magrittr %>%
-##' @export
+#' Get monthly download stats of cran package(s)
+#'
+#' @description
+#' Get monthly download stats of cran package(s), up to 500 packages at a time.
+#'
+#' @param packages packages
+#' @param use_cache logical, should cached data be used? Default: TRUE. If set to FALSE, it will re-query download stats and update cache.
+#' @param progress logical, should a progress bar be shown? Default: TRUE. When TRUE, a text progress bar will display “fetching data for `year-month`” as each month’s range is fetched.
+#' @return data.frame
+#' @importFrom jsonlite fromJSON
+#' @importFrom magrittr %>%
+#' @export
 cran_stats <- function(packages, use_cache=TRUE, progress=TRUE) {
+    if (length(packages) > 500) {
+        stop(paste0("You have requested ", length(packages), " packages. You can only get up to 500 packages at a time."))
+    }
+    
     stats_cache <- get_from_cache(packages)
     if (use_cache) {
         packages <- packages[!packages %in% stats_cache$package]

--- a/R/cran_stats.R
+++ b/R/cran_stats.R
@@ -1,7 +1,7 @@
-#' Get monthly download stats of cran package(s)
+#' Get monthly download stats of CRAN package(s)
 #'
 #' @description
-#' Get monthly download stats of cran package(s), up to 500 packages at a time.
+#' Get monthly download stats of CRAN package(s), up to 500 packages at a time.
 #'
 #' @param packages packages
 #' @param use_cache logical, should cached data be used? Default: TRUE. If set to FALSE, it will re-query download stats and update cache.

--- a/R/cran_stats.R
+++ b/R/cran_stats.R
@@ -3,20 +3,13 @@
 ##'
 ##' @title cran_stats
 ##' @param packages packages
-##' @param use_cache logical, should cached data be used? Default: TRUE. If set to FALSE, it will
-##'   re-query download stats and update cache.
+##' @param use_cache logical, should cached data be used? Default: TRUE. If set to FALSE, it will re-query download stats and update cache.
+##' @param progress logical, should a progress bar be shown? Default: TRUE. When TRUE, a text progress bar will display “fetching data for `year-month`” as each month’s range is fetched.
 ##' @return data.frame
 ##' @importFrom jsonlite fromJSON
 ##' @importFrom magrittr %>%
 ##' @export
-##' @examples
-##' \dontrun{
-##' library("dlstats")
-##' x <- cran_stats(c("dlstats", "emojifont", "rvcheck"), use_cache=TRUE)
-##' head(x)
-##' }
-##' @author Guangchuang Yu
-cran_stats <- function(packages, use_cache=TRUE) {
+cran_stats <- function(packages, use_cache=TRUE, progress=TRUE) {
     stats_cache <- get_from_cache(packages)
     if (use_cache) {
         packages <- packages[!packages %in% stats_cache$package]
@@ -45,15 +38,44 @@ cran_stats <- function(packages, use_cache=TRUE) {
         } else {
             mend <- all_months[i+1]-1
         }
-
         paste0("https://cranlogs.r-pkg.org/downloads/total/",
                mstart, ":", mend, "/", pkgs)
     })
 
-    stats <- lapply(urls, function(url) {
-        tryCatch(fromJSON(suppressWarnings(readLines(url))),
-                 error = function(e) NULL)
+    if (progress) {
+        pb <- txtProgressBar(min = 0, max = n, style = 3)
+        cat("\r\033[K") # clear the initial bar line
+    }
+    stats <- lapply(seq_along(urls), function(i) {
+        mstart <- all_months[i]
+        if (i == n) {
+            mend <- end
+        } else {
+            mend <- all_months[i+1] - 1
+        }
+
+        if (progress) {
+            # clear previous message+bar on iterations >1
+            if (i > 1) {
+                cat("\033[1A\r\033[K")  # clear old bar line
+                cat("\033[1A\r\033[K")  # clear old message line
+            }
+            # update message with current month
+            cat(sprintf("dlstats: fetching data for %s\n", format(mstart, "%Y-%m")))
+            # render progress bar
+            setTxtProgressBar(pb, i)
+            cat("\n")
+        }
+
+        result <- tryCatch(
+            fromJSON(suppressWarnings(readLines(urls[i]))),
+            error = function(e) NULL
+        )
+        result
     }) %>% do.call('rbind', .)
+    if (progress) {
+        close(pb)
+    }
 
     if (is.null(stats)) {
         warning(paste("--> OMITTED:", pkgs, "download stats not found or currently not available..."))

--- a/man/bioc_stats.Rd
+++ b/man/bioc_stats.Rd
@@ -4,15 +4,16 @@
 \alias{bioc_stats}
 \title{bioc_stats}
 \usage{
-bioc_stats(packages, use_cache = TRUE, type = "Software")
+bioc_stats(packages, use_cache = TRUE, type = "Software", progress = TRUE)
 }
 \arguments{
 \item{packages}{packages}
 
-\item{use_cache}{logical, should cached data be used? Default: TRUE. If set to FALSE, it will
-re-query download stats and update cache.}
+\item{use_cache}{logical, should cached data be used? Default: TRUE. If set to FALSE, it will re-query download stats and update cache.}
 
 \item{type}{one of "Software", "AnnotationData", "ExperimentData", and "Workflow"}
+
+\item{progress}{logical, should a progress bar be shown? Default: TRUE. When TRUE, prints a the current package name and a text progress bar.}
 }
 \value{
 data.frame
@@ -24,7 +25,7 @@ monthly download stats of Bioconductor package(s)
 \dontrun{
 library("dlstats")
 pkgs <- c("ChIPseeker", "clusterProfiler", "DOSE", "ggtree", "GOSemSim", "ReactomePA")
-y <- bioc_stats(pkgs, use_cache=TRUE)
+y <- bioc_stats(pkgs, use_cache=TRUE, progress=TRUE)
 head(y)
 }
 }

--- a/man/cran_stats.Rd
+++ b/man/cran_stats.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/cran_stats.R
 \name{cran_stats}
 \alias{cran_stats}
-\title{Get monthly download stats of cran package(s)}
+\title{Get monthly download stats of CRAN package(s)}
 \usage{
 cran_stats(packages, use_cache = TRUE, progress = TRUE)
 }
@@ -17,5 +17,5 @@ cran_stats(packages, use_cache = TRUE, progress = TRUE)
 data.frame
 }
 \description{
-Get monthly download stats of cran package(s), up to 500 packages at a time.
+Get monthly download stats of CRAN package(s), up to 500 packages at a time.
 }

--- a/man/cran_stats.Rd
+++ b/man/cran_stats.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/cran_stats.R
 \name{cran_stats}
 \alias{cran_stats}
-\title{cran_stats}
+\title{Get monthly download stats of cran package(s)}
 \usage{
 cran_stats(packages, use_cache = TRUE, progress = TRUE)
 }
@@ -17,5 +17,5 @@ cran_stats(packages, use_cache = TRUE, progress = TRUE)
 data.frame
 }
 \description{
-monthly download stats of cran package(s)
+Get monthly download stats of cran package(s), up to 500 packages at a time.
 }

--- a/man/cran_stats.Rd
+++ b/man/cran_stats.Rd
@@ -4,27 +4,18 @@
 \alias{cran_stats}
 \title{cran_stats}
 \usage{
-cran_stats(packages, use_cache = TRUE)
+cran_stats(packages, use_cache = TRUE, progress = TRUE)
 }
 \arguments{
 \item{packages}{packages}
 
-\item{use_cache}{logical, should cached data be used? Default: TRUE. If set to FALSE, it will
-re-query download stats and update cache.}
+\item{use_cache}{logical, should cached data be used? Default: TRUE. If set to FALSE, it will re-query download stats and update cache.}
+
+\item{progress}{logical, should a progress bar be shown? Default: TRUE. When TRUE, a text progress bar will display “fetching data for `year-month`” as each month’s range is fetched.}
 }
 \value{
 data.frame
 }
 \description{
 monthly download stats of cran package(s)
-}
-\examples{
-\dontrun{
-library("dlstats")
-x <- cran_stats(c("dlstats", "emojifont", "rvcheck"), use_cache=TRUE)
-head(x)
-}
-}
-\author{
-Guangchuang Yu
 }


### PR DESCRIPTION
@GuangchuangYu hi, I added a simple progress bar (on by default) to `cran_stats()`, and also I hardcoded a limit for 500 packages at a time, as this is a somewhat reasonable maximum that https://cranlogs.r-pkg.org/ API accepts. It seems to accept more, but I think it may have more to do with the length of a request URL, and due variability in length of package names, I would stick to 500, as at 600 my tests were already sometimes failing.